### PR TITLE
Adding ability to set certificate authority for a request to a self signed auth endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ function AuthTokenValidator(opts) {
 	this._maxKeyAge = 'number' === typeof opts.maxKeyAge ? opts.maxKeyAge : DEFAULT_MAX_KEY_AGE;
 	this._keyCache = new Map();
 	this._keysUpdating = null;
+	this._cert = opts.cert;
 }
 
 AuthTokenValidator.prototype.fromHeaders = promised(/* @this */function getValidatedAuthTokenFromHeaders(headers) {
@@ -206,6 +207,9 @@ AuthTokenValidator.prototype._updatePublicKeys = function updatePublicKeys() {
 		this._keysUpdating = new Promise(function(resolve, reject) {
 			request
 				.get(self._jwksUri)
+				.use(function(req) {
+					return (self._cert) ? req.ca(self._cert) : req;
+				})
 				.end(function(err, res) {
 					if (err) {
 						reject(new errors.PublicKeyLookupFailed(err));


### PR DESCRIPTION
This is a follow up to the conversation (https://github.com/Brightspace/node-auth-validation/pull/29#issuecomment-264264726). 