### PR TITLE
Changing header regex to allow multiple spaces.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ AuthTokenValidator.prototype.fromHeaders = promised(/* @this */function getValid
 		throw new errors.NoAuthorizationProvided();
 	}
 
-	const signatureMatch = authHeader.match(/^Bearer (.+)$/);
+	const signatureMatch = authHeader.match(/^Bearer\s+(.+)$/);
 	if (!signatureMatch) {
 		throw new errors.NoAuthorizationProvided();
 	}


### PR DESCRIPTION
>      credentials = "Bearer" 1*SP b64token
> https://tools.ietf.org/html/rfc6750#section-2.1

Based on https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html:
* SP == space
* 1* == at least one

(Looking for confirmation I'm reading the spec correctly, and if I am, I can look into the tests).